### PR TITLE
Configure setuptools package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,12 @@ dependencies = [
   "jax-cosmo",
 ]
 
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
 [tool.ruff]
 line-length = 100
 target-version = "py311"


### PR DESCRIPTION
## Summary
- ensure setuptools finds packages under `src` so `desi_cmb_fli` is installed

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b06e972bec83278a1d3476b7e9b863