### PR TITLE
Expose seed and output options in demo script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ pip install -e .
 pytest -q
 
 # 4) Try the minimal demo (synthetic box → FLI toy)
-python scripts/run_demo.py
+python scripts/run_demo.py --seed 0 --output figures/toy_summary.png
 ```
+
+The script accepts `--seed` and `--output` arguments to control the random seed and
+where the summary plot is written.
 
 > **Note**: Large datasets and maps are **not** stored in this repo. See `data/README.md` and `docs/data_access.md` for instructions.
 

--- a/scripts/run_demo.py
+++ b/scripts/run_demo.py
@@ -1,3 +1,6 @@
+"""Minimal demo script for the toy field-level inference pipeline."""
+
+from argparse import ArgumentParser, Namespace
 from pathlib import Path
 
 from desi_cmb_fli.analysis.plots import save_toy_plot
@@ -7,12 +10,31 @@ from desi_cmb_fli.utils.logging import setup_logger
 log = setup_logger()
 
 
-def main():
-    results = toy_fli(seed=0)
+def parse_args() -> Namespace:
+    """CLI options for the demo."""
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed for the toy FLI run (default: 0)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("figures/toy_summary.png"),
+        help="Path to save the summary plot (default: figures/toy_summary.png)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    results = toy_fli(seed=args.seed)
     val = results["summary"]["toy_power"]
     log.info(f"Toy power: {val:.3e}")
-    save_toy_plot(val, Path("figures/toy_summary.png"))
-    log.info("Saved figures/toy_summary.png")
+    save_toy_plot(val, args.output)
+    log.info(f"Saved {args.output}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make `scripts/run_demo.py` configurable via `--seed` and `--output`
- document new CLI arguments in the quick-start section of `README.md`

## Testing
- `pre-commit run --files scripts/run_demo.py README.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b06ea9f6988327a9d5625ffa362214