### PR TITLE
Add synthetic data tests for loaders and plotting

### DIFF
--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pytest
+import healpy as hp
+import fitsio
+
+from desi_cmb_fli.data.loaders import load_planck_kappa_pr4, load_desi_lrg_catalog
+
+
+def test_load_planck_kappa_pr4(tmp_path):
+    nside = 2
+    kappa = np.arange(hp.nside2npix(nside), dtype=np.float64)
+    path = tmp_path / "kappa.fits"
+    hp.write_map(path, kappa, dtype=np.float64, overwrite=True)
+    data = load_planck_kappa_pr4(path)
+    assert data["nside"] == nside
+    assert np.allclose(data["kappa"], kappa)
+
+
+def test_load_planck_kappa_pr4_missing(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_planck_kappa_pr4(tmp_path / "missing.fits")
+
+
+def test_load_desi_lrg_catalog(tmp_path):
+    path = tmp_path / "lrg.fits"
+    ra = np.array([0.1, 1.2])
+    dec = np.array([-0.5, 2.5])
+    z = np.array([0.5, 1.0])
+    with fitsio.FITS(path, "rw", clobber=True) as f:
+        f.write([ra, dec, z], names=["RA", "DEC", "Z"])
+    data = load_desi_lrg_catalog(path)
+    assert np.allclose(data["ra"], ra)
+    assert np.allclose(data["dec"], dec)
+    assert np.allclose(data["z"], z)
+
+
+def test_load_desi_lrg_catalog_missing(tmp_path):
+    with pytest.raises(OSError):
+        load_desi_lrg_catalog(tmp_path / "missing.fits")

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -1,0 +1,10 @@
+import matplotlib
+matplotlib.use("Agg")
+
+from desi_cmb_fli.analysis.plots import save_toy_plot
+
+
+def test_save_toy_plot(tmp_path):
+    out = tmp_path / "toy.png"
+    save_toy_plot(0.3, out)
+    assert out.exists()


### PR DESCRIPTION
## Summary
- add synthetic healpy map tests for `load_planck_kappa_pr4`
- add small FITS table tests for `load_desi_lrg_catalog`
- verify `save_toy_plot` saves a file

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b06eb5b0a88327b50a989461bc5662